### PR TITLE
Fixed regex to parse Issues over 10

### DIFF
--- a/dumbpig/dumbpig.py
+++ b/dumbpig/dumbpig.py
@@ -142,7 +142,7 @@ class RuleChecker(object):
             raise RuleCheckerError('No data to process. Run the test then '
                                    'process results')
         # Parses the output data with regex to split up each Issue
-        regex_issues = re.compile("Issue [1-999999999] \n(.*?)\n\=", re.DOTALL)
+        regex_issues = re.compile("Issue [1-9][0-9]* \n(.*?)\n\=", re.DOTALL)
         output_data = regex_issues.findall(self._dumbpig_output)
 
         regex_problem = re.compile("(.*?)\n\nalert")


### PR DESCRIPTION
The regex being used to parse the output data and split up each issue only matches Issue's from 1 to 9. `[1-999999999]` matches a single character in the range between 1 and 9 and the literal character 9. It's the same regex as `[1-99]` and `[1-9]`. 

I've updated it with a new regex that matches 1 to infinite Issue's.
